### PR TITLE
Fixes to work with Zig 2022

### DIFF
--- a/benchmarks/zig/async.zig
+++ b/benchmarks/zig/async.zig
@@ -6,7 +6,7 @@ const ThreadPool = @import("thread_pool");
 var thread_pool: ThreadPool = undefined;
 
 /// Global allocator which mimics other async runtimes
-pub var allocator: *std.mem.Allocator = undefined;
+pub var allocator: std.mem.Allocator = undefined;
 
 /// Zig async wrapper around ThreadPool.Task
 const Task = struct {
@@ -59,7 +59,7 @@ pub fn run(comptime asyncFn: anytype, args: anytype) ReturnTypeOf(asyncFn) {
     if (is_windows) {
         win_heap = @TypeOf(win_heap).init();
         win_heap.heap_handle = std.os.windows.kernel32.GetProcessHeap() orelse unreachable;
-        allocator = &win_heap.allocator;
+        allocator = win_heap.allocator;
     } else if (builtin.link_libc) {
         allocator = std.heap.c_allocator;
     } else {

--- a/benchmarks/zig/qsort.zig
+++ b/benchmarks/zig/qsort.zig
@@ -10,16 +10,16 @@ pub fn main() void {
 fn asyncMain() void {
     const arr = Async.allocator.alloc(i32, SIZE) catch @panic("failed to allocate array");
     defer Async.allocator.free(arr);
-    
-    std.debug.warn("filling\n", .{});
+
+    std.debug.print("filling\n", .{});
     for (arr) |*item, i| {
         item.* = @intCast(i32, i);
     }
 
-    std.debug.warn("shuffling\n", .{});
+    std.debug.print("shuffling\n", .{});
     shuffle(arr);
 
-    std.debug.warn("running\n", .{});
+    std.debug.print("running\n", .{});
     var timer = std.time.Timer.start() catch @panic("failed to create os timer");
     quickSort(arr);
 
@@ -36,7 +36,7 @@ fn asyncMain() void {
         units = "us";
     }
 
-    std.debug.warn("took {d:.2}{s}\n", .{ elapsed, units });
+    std.debug.print("took {d:.2}{s}\n", .{ elapsed, units });
     if (!verify(arr)) {
         std.debug.panic("array not sorted", .{});
     }

--- a/src/thread_pool_go_based.zig
+++ b/src/thread_pool_go_based.zig
@@ -1,3 +1,4 @@
+const builtin = @import("builtin");
 const std = @import("std");
 const assert = std.debug.assert;
 const Atomic = std.atomic.Atomic;
@@ -218,7 +219,7 @@ const Thread = struct {
 
             // assert(sync.stealing > 0);
             if (sync.stealing == 0) {
-                std.debug.warn("{} resetspinning(): {}\n", .{std.Thread.getCurrentId(), sync});
+                std.debug.print("{} resetspinning(): {}\n", .{std.Thread.getCurrentId(), sync});
                 unreachable;
             }
 
@@ -526,7 +527,7 @@ const Node = struct {
                 // On x86, a fetchAdd ("lock xadd") can be faster than a tryCompareAndSwap ("lock cmpxchg").
                 // If the increment makes the head go past the tail, it means the queue was emptied before we incremented so revert.
                 // Acquire barrier to ensure that any writes we do to the popped Node only happen after the head increment.
-                if (comptime std.builtin.target.cpu.arch.isX86()) {
+                if (comptime builtin.target.cpu.arch.isX86()) {
                     head = self.head.fetchAdd(1, .Acquire);
                     if (head == tail) {
                         self.head.store(head, .Monotonic);
@@ -561,7 +562,7 @@ const Node = struct {
 
                 // On x86, the target buffer thread uses fetchAdd to increment the head which can go over if it's zero.
                 // Account for that here by understanding that it's empty here.
-                if (comptime std.builtin.target.cpu.arch.isX86()) {
+                if (comptime builtin.target.cpu.arch.isX86()) {
                     if (head == tail +% 1) {
                         return false;
                     }
@@ -627,7 +628,7 @@ const Node = struct {
 
                 // On x86, the target buffer thread uses fetchAdd to increment the head which can go over if it's zero.
                 // Account for that here by understanding that it's empty here.
-                if (comptime std.builtin.target.cpu.arch.isX86()) {
+                if (comptime builtin.target.cpu.arch.isX86()) {
                     if (buffer_head == buffer_tail +% 1) {
                         return null;
                     }


### PR DESCRIPTION
- the `Allocator` interface changed
  (uses vtable + type-erased impl pointer)
- `std.debug.warn` was removed from the std library
- `std.builtin.target.cpu.arch.isX86()` is also unavailable in modern Zig.