### PR TITLE
v2: Bring build system up to date with zig master (0.15.0-dev)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,7 +4,7 @@ pub fn build(b: *Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    _ = b.addModule("zig-datetime", .{ .root_source_file = b.path("v2.zig") });
+    _ = b.addModule("zap", .{ .root_source_file = b.path("v2.zig") });
 
     const exe = b.addExecutable(.{
         .name = "bench",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "zap",
+    .name = .zap,
     .version = "0.2.0",
+    .fingerprint = 0x8ac41f4e8bb7b240,
     .paths = .{"."},
 }


### PR DESCRIPTION
I only changed the package name to an enum literal and added a fingerprint field to conform to the latest build.zig.zon spec.
Also the module exposed by build.zig was called "zig-datetime" I assume that's supposed to be "zap" :)